### PR TITLE
Fix version conflicts caused by PR#205

### DIFF
--- a/Ghpr.SpecFlowPlugin/Ghpr.NUnit.SpecFlowPlugin/GhprNUnit.SpecFlowPlugin.csproj
+++ b/Ghpr.SpecFlowPlugin/Ghpr.NUnit.SpecFlowPlugin/GhprNUnit.SpecFlowPlugin.csproj
@@ -24,10 +24,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Ghpr.Core" Version="0.9.9.9" />
     <PackageReference Include="Ghpr.LocalFileSystem" Version="0.9.9.9" />
-    <PackageReference Include="BoDi" Version="1.4.1" />
-    <PackageReference Include="Gherkin" Version="6.0.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="SpecFlow" Version="3.1.62" />
+    <PackageReference Include="BoDi" Version="1.5.0" />
+    <PackageReference Include="Gherkin" Version="19.0.3" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
+    <PackageReference Include="SpecFlow" Version="3.9.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ghpr.SpecFlow.Common\GhprSpecFlow.Common.csproj" />

--- a/Ghpr.SpecFlowPlugin/Ghpr.SpecFlow.Common/GhprSpecFlow.Common.csproj
+++ b/Ghpr.SpecFlowPlugin/Ghpr.SpecFlow.Common/GhprSpecFlow.Common.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Ghpr.Core" Version="0.9.9.9" />
     <PackageReference Include="Ghpr.LocalFileSystem" Version="0.9.9.9" />
-    <PackageReference Include="BoDi" Version="1.4.1" />
-    <PackageReference Include="Gherkin" Version="6.0.0" />
-    <PackageReference Include="SpecFlow" Version="3.1.62" />
+    <PackageReference Include="BoDi" Version="1.5.0" />
+    <PackageReference Include="Gherkin" Version="19.0.3" />
+    <PackageReference Include="SpecFlow" Version="3.9.8" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Ghpr.SpecFlow.Settings.json">

--- a/Ghpr.SpecFlowPlugin/Ghpr.SpecFlowPlugin/Ghpr.SpecFlowPlugin.csproj
+++ b/Ghpr.SpecFlowPlugin/Ghpr.SpecFlowPlugin/Ghpr.SpecFlowPlugin.csproj
@@ -24,9 +24,9 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Ghpr.Core" Version="0.9.9.9" />
     <PackageReference Include="Ghpr.LocalFileSystem" Version="0.9.9.9" />
-    <PackageReference Include="BoDi" Version="1.4.1" />
-    <PackageReference Include="Gherkin" Version="6.0.0" />
-    <PackageReference Include="SpecFlow" Version="3.1.62" />
+    <PackageReference Include="BoDi" Version="1.5.0" />
+    <PackageReference Include="Gherkin" Version="19.0.3" />
+    <PackageReference Include="SpecFlow" Version="3.9.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ghpr.SpecFlow.Common\GhprSpecFlow.Common.csproj" />

--- a/Ghpr.SpecFlowPlugin/Ghpr.TestsForDebug.MSTest/Ghpr.TestsForDebug.MSTestTests.csproj
+++ b/Ghpr.SpecFlowPlugin/Ghpr.TestsForDebug.MSTest/Ghpr.TestsForDebug.MSTestTests.csproj
@@ -26,12 +26,12 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Ghpr.Core" Version="0.9.9.9" />
     <PackageReference Include="Ghpr.LocalFileSystem" Version="0.9.9.9" />
-    <PackageReference Include="BoDi" Version="1.4.1" />
-    <PackageReference Include="Gherkin" Version="6.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="SpecFlow" Version="3.1.62" />
-    <PackageReference Include="SpecFlow.MsTest" Version="3.1.62" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.62" />
+    <PackageReference Include="BoDi" Version="1.5.0" />
+    <PackageReference Include="Gherkin" Version="19.0.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="SpecFlow" Version="3.9.8" />
+    <PackageReference Include="SpecFlow.MsTest" Version="3.9.8" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ghpr.SpecFlow.Common\GhprSpecFlow.Common.csproj" />

--- a/Ghpr.SpecFlowPlugin/Ghpr.TestsForDebug/Ghpr.TestsForDebug.NUnitTests.csproj
+++ b/Ghpr.SpecFlowPlugin/Ghpr.TestsForDebug/Ghpr.TestsForDebug.NUnitTests.csproj
@@ -24,13 +24,13 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Ghpr.Core" Version="0.9.9.9" />
     <PackageReference Include="Ghpr.LocalFileSystem" Version="0.9.9.9" />
-    <PackageReference Include="BoDi" Version="1.4.1" />
-    <PackageReference Include="Gherkin" Version="6.0.0" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="BoDi" Version="1.5.0" />
+    <PackageReference Include="Gherkin" Version="19.0.3" />
+    <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="SpecFlow" Version="3.1.62" />
-    <PackageReference Include="SpecFlow.NUnit" Version="3.1.62" />
-    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.1.62" />
+    <PackageReference Include="SpecFlow" Version="3.9.8" />
+    <PackageReference Include="SpecFlow.NUnit" Version="3.9.8" />
+    <PackageReference Include="SpecFlow.Tools.MsBuild.Generation" Version="3.9.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ghpr.NUnit.SpecFlowPlugin\GhprNUnit.SpecFlowPlugin.csproj" />

--- a/Ghpr.SpecFlowPlugin/GhprMSTest.SpecFlowPlugin/GhprMSTest.SpecFlowPlugin.csproj
+++ b/Ghpr.SpecFlowPlugin/GhprMSTest.SpecFlowPlugin/GhprMSTest.SpecFlowPlugin.csproj
@@ -24,10 +24,10 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Ghpr.Core" Version="0.9.9.9" />
     <PackageReference Include="Ghpr.LocalFileSystem" Version="0.9.9.9" />
-    <PackageReference Include="BoDi" Version="1.4.1" />
-    <PackageReference Include="Gherkin" Version="6.0.0" />
+    <PackageReference Include="BoDi" Version="1.5.0" />
+    <PackageReference Include="Gherkin" Version="19.0.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="SpecFlow" Version="3.1.62" />
+    <PackageReference Include="SpecFlow" Version="3.9.8" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Ghpr.SpecFlow.Common\GhprSpecFlow.Common.csproj" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump SpecFlow from 3.1.62 to 3.9.8 in /Ghpr.SpecFlowPlugin. [(PR#205)](https://github.com/GHPReporter/Ghpr.SpecFlow/pull/205).
Hope this fix can help you.

Best regards,
sucrose